### PR TITLE
Fix resetting of viewDate

### DIFF
--- a/js/bootstrap-datetimepicker.js
+++ b/js/bootstrap-datetimepicker.js
@@ -546,7 +546,7 @@
       this.datesDisabled = $.map(this.datesDisabled, function (d) {
         return DPGlobal.parseDate(d, mThis.format, mThis.language, mThis.formatType, mThis.timezone).toDateString();
       });
-      this.update();
+      this.fill();
       this.updateNavArrows();
     },
 

--- a/tests/run-qunit.js
+++ b/tests/run-qunit.js
@@ -53,8 +53,8 @@ page.onError = function (msg, trace) {
         console.log('  ', item.file, ':', item.line);
     })
 }
-
-var _openPath = phantom.args[0].replace(/^.*(\\|\/)/, '');
+args = system.args.toString().split(',');
+var _openPath = args[1].replace(/^.*(\\|\/)/, '');
 var openPath = _openPath;
 var origdir = '../js/';
 var basedir = '../instrumented/';

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -288,6 +288,23 @@ test('DaysOfWeekDisabled', function(){
     ok(target.hasClass('disabled'), 'Day of week is disabled');
 });
 
+test('setDatesDisabled', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-10-26')
+                .datetimepicker({
+                    format: 'yyyy-mm-dd',
+                }),
+        dp = input.data('datetimepicker'),
+        picker = dp.picker,
+        target;
+
+    input.datetimepicker('setDatesDisabled', ['2012-10-28']);
+    input.focus();
+    target = picker.find('.datetimepicker-days tbody td:nth(28)');
+    ok(target.hasClass('disabled'), 'Set dates disabled');
+});
+
 test('startDate: Custom value', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')


### PR DESCRIPTION
Fix for https://github.com/smalot/bootstrap-datetimepicker/issues/617. 
Added new test for setDatesDisabled. 
Fixed phantomjs error.

I had sent this to https://github.com/smalot/bootstrap-datetimepicker/pull/619 just before reading the Readme and realize of this new repo